### PR TITLE
Add Flask route tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import pytest
+
+# Ensure the app module can be imported
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+from app import app
+
+class DummyResponse:
+    status_code = 200
+    def json(self):
+        return {}
+
+def test_home_route():
+    with app.test_client() as client:
+        resp = client.get('/')
+        assert resp.status_code == 200
+
+def test_result_invalid_ip(monkeypatch):
+    monkeypatch.setattr(app.requests, 'get', lambda *args, **kwargs: DummyResponse())
+    monkeypatch.setattr(app, 'threat_intelligence_api_token', lambda ip, token: {'is_malicious': False})
+    with app.test_client() as client:
+        resp = client.post('/result', data={'ip_address': 'invalid'})
+        assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- add pytest suite covering `/` and `/result`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845808fa6248330816f5c4b1a2c2d80