### PR TITLE
Display malicious info and close HTML

### DIFF
--- a/templates/result.html
+++ b/templates/result.html
@@ -14,6 +14,8 @@
         <p>City: {{ city }}</p>
         <p>Country: {{ country }}</p>
         <p>Anomaly Score: {{ anomaly_score }}</p>
+        <p>Malicious: {{ is_malicious }}</p>
         <a href="{{ url_for('home') }}">Analyze Another IP Address</a>
     </div>
 </body>
+</html>


### PR DESCRIPTION
## Summary
- add malicious indicator to results page
- close off HTML document properly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845808ad6b883308c200d8664a35575