### PR TITLE
Fix invalid monkeypatch usage in tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,23 +2,23 @@ import os
 import sys
 import pytest
 
-# Ensure the app module can be imported
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 from app import app
 
-class DummyResponse:
-    status_code = 200
-    def json(self):
-        return {}
+
+async def dummy_fetch(*args, **kwargs):
+    return {}
+
 
 def test_home_route():
     with app.test_client() as client:
-        resp = client.get('/')
+        resp = client.get("/")
         assert resp.status_code == 200
 
+
 def test_result_invalid_ip(monkeypatch):
-    monkeypatch.setattr(app.requests, 'get', lambda *args, **kwargs: DummyResponse())
-    monkeypatch.setattr(app, 'threat_intelligence_api_token', lambda ip, token: {'is_malicious': False})
+    monkeypatch.setattr(app, "fetch_ipinfo", dummy_fetch)
+    monkeypatch.setattr(app, "fetch_threat_intelligence", dummy_fetch)
     with app.test_client() as client:
-        resp = client.post('/result', data={'ip_address': 'invalid'})
+        resp = client.post("/result", data={"ip_address": "invalid"})
         assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- fix tests to monkeypatch asynchronous fetch functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845840bc80083308b7f6a382d6e984d